### PR TITLE
Style: align back home and external link indicators

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -235,6 +235,17 @@ nav .my-active-class a {
   color: var(--accent);
 }
 
+.back-home:link,
+.back-home:visited {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 400;
+}
+
+.back-home:hover {
+  color: var(--accent);
+}
+
 /* Things section */
 .things-section {
   margin-top: 48px;

--- a/src/_includes/layouts/home.njk
+++ b/src/_includes/layouts/home.njk
@@ -31,7 +31,7 @@ templateClass: tmpl-home
             <a href="{{ post.data.link }}" class="thing-link">
               <span>{{ post.data.title }}</span>
               <span class="thing-desc">{{ post.data.description }}</span>
-              <span class="arrow">→</span>
+              <span class="arrow">{% if post.data.link and ('http' in post.data.link) %}↗{% else %}→{% endif %}</span>
             </a>
           </div>
           {%- endif -%}

--- a/src/_includes/layouts/posts.njk
+++ b/src/_includes/layouts/posts.njk
@@ -10,7 +10,7 @@ templateClass: tmpl-home
       {%- for post in collections.posts  | reverse -%}
         <li{% if page.url == post.url %} aria-current="page"{% endif %}>{{ post.data.page.date | htmlDateString }} — <a href='{{ post.url }}'>{{ post.data.title }}</a></li>
       {%- endfor -%}
-      <li><a href="/"><-Back Home</a></li>
+      <li><a class="back-home" href="/">← back home</a></li>
     </ul>
   </div>
 </div>

--- a/src/_includes/layouts/things.njk
+++ b/src/_includes/layouts/things.njk
@@ -7,6 +7,6 @@ templateClass: tmpl-home
   <div class="content">
     {{ content | safe }}
       {% include 'layouts/blocks/things.njk' %}
-      <li><a href="/"><-Back Home</a></li>
+      <li><a class="back-home" href="/">← back home</a></li>
   </div>
 </div>


### PR DESCRIPTION
Updated the back home link to use a grey arrow (← back home) matching the view all → style. Also added external link indicator (↗) to things on the homepage, consistent with the Things page.