### PR TITLE
Add resume page with styling and navigation

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -856,6 +856,16 @@ footer a:hover {
   font-weight: 400;
 }
 
+.resume-desc {
+  display: block;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 400;
+  margin-top: 2px;
+  max-width: 480px;
+  line-height: 1.6;
+}
+
 .resume-links .thing-item {
   padding: 6px 0;
 }

--- a/public/style.css
+++ b/public/style.css
@@ -796,6 +796,70 @@ footer a:hover {
   border-color: var(--accent);
 }
 
+/* Resume */
+.resume-section {
+  margin-top: 40px;
+}
+
+.resume-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.resume-list > li {
+  display: flex;
+  align-items: baseline;
+  gap: 24px;
+  padding: 10px 0;
+  margin-bottom: 0;
+}
+
+.resume-date {
+  color: var(--muted);
+  font-size: 12px;
+  white-space: nowrap;
+  min-width: 110px;
+}
+
+.resume-entry {
+  flex: 1;
+}
+
+.resume-entry strong {
+  font-weight: 600;
+}
+
+.resume-entry a:link,
+.resume-entry a:visited {
+  color: var(--fg);
+  font-weight: 600;
+}
+
+.resume-entry a:hover {
+  color: var(--accent);
+}
+
+.resume-entry .arrow {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.resume-entry a:hover .arrow {
+  color: var(--accent);
+}
+
+.resume-org {
+  display: block;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 400;
+}
+
+.resume-links .thing-item {
+  padding: 6px 0;
+}
+
 /* Responsive */
 @media screen and (max-width: 480px) {
   body {
@@ -822,5 +886,14 @@ footer a:hover {
 
   .things-list .thing-desc {
     display: none;
+  }
+
+  .resume-list > li {
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .resume-date {
+    min-width: unset;
   }
 }

--- a/src/_includes/layouts/resume.njk
+++ b/src/_includes/layouts/resume.njk
@@ -1,0 +1,12 @@
+---
+layout: layouts/base.njk
+templateClass: tmpl-resume
+---
+
+<div class="wrapper post">
+  <div>
+    {% include 'layouts/blocks/breadcrumbs.njk' %}
+
+    {{ content | safe }}
+  </div>
+</div>

--- a/src/about/about.json
+++ b/src/about/about.json
@@ -1,0 +1,3 @@
+{
+  "layout": "layouts/page.njk"
+}

--- a/src/about/index.md
+++ b/src/about/index.md
@@ -26,3 +26,5 @@ I've been building up and riding bikes since I was a kid. I pop into bike shops 
 Hiking, biking, camping and skiing are how I stretch my legs. I travel to experience natural beauty and the fruits of human creativity. My last big move was across Canada for a fellowship, and now I'm in Germany.
 
 If you've read this far, [drop me a line](mailto:sup+marcsist@marcsist.com)
+
+<div class="view-all"><a href="/about/resume/">view resume →</a></div>

--- a/src/about/resume.md
+++ b/src/about/resume.md
@@ -15,31 +15,50 @@ eleventyNavigation:
   <div class="section-label">// experience</div>
   <ul class="resume-list">
     <li>
-      <span class="resume-date">2021 — Now</span>
+      <span class="resume-date">2026 — Now</span>
       <div class="resume-entry">
-        <a href="https://www.rasa.com/"><strong>Director, Product Design at Rasa</strong> <span class="arrow">↗</span></a>
+        <a href="https://www.rasa.com/"><strong>Director of Product Design at Rasa</strong> <span class="arrow">↗</span></a>
+        <span class="resume-org">Berlin, Germany · Remote</span>
+      </div>
+    </li>
+    <li>
+      <span class="resume-date">2023 — 2026</span>
+      <div class="resume-entry">
+        <a href="https://www.phrase.com/"><strong>Director, Product Design at Phrase</strong> <span class="arrow">↗</span></a>
+        <span class="resume-org">Hamburg, Germany · Hybrid</span>
+        <span class="resume-desc">Led product design across a localization SaaS suite — UI, design system, user research, and content design. Kept products relevant, AI-driven and user-centric.</span>
+      </div>
+    </li>
+    <li>
+      <span class="resume-date">2021 — 2023</span>
+      <div class="resume-entry">
+        <strong>Product Design Lead at Phrase</strong>
+        <span class="resume-org">Hamburg, Germany · Hybrid</span>
+        <span class="resume-desc">Aligned two legacy products under a shared design language. Introduced a combined product suite experience. Doubled design headcount.</span>
+      </div>
+    </li>
+    <li>
+      <span class="resume-date">2021</span>
+      <div class="resume-entry">
+        <strong>Product Designer at Phrase</strong>
         <span class="resume-org">Hamburg, Germany</span>
+        <span class="resume-desc">Rebuilt the core String Editor from the ground up. Established a research insights database. Co-developed the Syntax Design System.</span>
       </div>
     </li>
     <li>
-      <span class="resume-date">2018 — 2021</span>
+      <span class="resume-date">2018 — 2020</span>
       <div class="resume-entry">
-        <strong>Senior Product Designer at Rasa</strong>
-        <span class="resume-org">Hamburg, Germany</span>
+        <strong>Product Designer & PM at Sema</strong>
+        <span class="resume-org">Halifax, Canada · Remote</span>
+        <span class="resume-desc">Design and product management for a code quality analytics platform. Design system, in-product analytics, and BI reporting for Fortune 500 customers.</span>
       </div>
     </li>
     <li>
-      <span class="resume-date">2015 — 2018</span>
+      <span class="resume-date">2016 — 2020</span>
       <div class="resume-entry">
-        <strong>Product Designer</strong>
-        <span class="resume-org">Previous Role</span>
-      </div>
-    </li>
-    <li>
-      <span class="resume-date">2012 — 2015</span>
-      <div class="resume-entry">
-        <strong>UX Designer</strong>
-        <span class="resume-org">Previous Role</span>
+        <strong>Freelance Product Designer, BIEM ETC.</strong>
+        <span class="resume-org">Dartmouth, Nova Scotia</span>
+        <span class="resume-desc">Independent practice spanning digital product &amp; UX design, technical soft goods, wearable tech, and industrial design.</span>
       </div>
     </li>
   </ul>
@@ -66,20 +85,14 @@ eleventyNavigation:
 </section>
 
 <section class="resume-section">
-  <div class="section-label">// education</div>
+  <div class="section-label">// recognition</div>
   <ul class="resume-list">
     <li>
-      <span class="resume-date">2010 — 2012</span>
+      <span class="resume-date">2017 — 2020</span>
       <div class="resume-entry">
-        <strong>Fellowship</strong>
+        <a href="https://ventureforcanada.ca/"><strong>Venture for Canada Fellow</strong> <span class="arrow">↗</span></a>
         <span class="resume-org">Canada</span>
-      </div>
-    </li>
-    <li>
-      <span class="resume-date">2006 — 2010</span>
-      <div class="resume-entry">
-        <strong>Design Degree</strong>
-        <span class="resume-org">University</span>
+        <span class="resume-desc">Fellowship supporting entrepreneurship and talent in Canadian startups.</span>
       </div>
     </li>
   </ul>
@@ -99,6 +112,13 @@ eleventyNavigation:
       <a href="https://github.com/marcsist" class="thing-link">
         <span>GitHub</span>
         <span class="thing-desc">marcsist</span>
+        <span class="arrow">↗</span>
+      </a>
+    </div>
+    <div class="thing-item">
+      <a href="https://www.linkedin.com/in/marcs-wilkinson/" class="thing-link">
+        <span>LinkedIn</span>
+        <span class="thing-desc">marcs-wilkinson</span>
         <span class="arrow">↗</span>
       </a>
     </div>

--- a/src/about/resume.md
+++ b/src/about/resume.md
@@ -99,6 +99,34 @@ eleventyNavigation:
 </section>
 
 <section class="resume-section">
+  <div class="section-label">// education</div>
+  <ul class="resume-list">
+    <li>
+      <span class="resume-date">2013 — 2017</span>
+      <div class="resume-entry">
+        <strong>Bachelor of Design, Product</strong>
+        <span class="resume-org">The Wilson School of Design at Kwantlen Polytechnic University</span>
+        <span class="resume-desc">Product Design Student Rep. HACKADAY Prize finalist for N+ platform — an open-source modular bike shoe with additive-enabled design.</span>
+      </div>
+    </li>
+    <li>
+      <span class="resume-date">2015</span>
+      <div class="resume-entry">
+        <strong>Exchange Semester, Industrial Design</strong>
+        <span class="resume-org">University of Applied Sciences and Arts Northwestern Switzerland FHNW</span>
+      </div>
+    </li>
+    <li>
+      <span class="resume-date">2008 — 2010</span>
+      <div class="resume-entry">
+        <strong>Diploma, Business Administration</strong>
+        <span class="resume-org">Camosun College</span>
+      </div>
+    </li>
+  </ul>
+</section>
+
+<section class="resume-section">
   <div class="section-label">// elsewhere</div>
   <div class="things-list resume-links">
     <div class="thing-item">

--- a/src/about/resume.md
+++ b/src/about/resume.md
@@ -1,0 +1,113 @@
+---
+layout: layouts/resume.njk
+title: Resume
+eleventyNavigation:
+  key: Resume
+  parent: About
+---
+
+<section id="hero">
+  <h1>Resume</h1>
+  <p>Creative technologist from Canada living in Germany, designing and managing products for humans doing things in new ways.</p>
+</section>
+
+<section class="resume-section">
+  <div class="section-label">// experience</div>
+  <ul class="resume-list">
+    <li>
+      <span class="resume-date">2021 — Now</span>
+      <div class="resume-entry">
+        <a href="https://www.rasa.com/"><strong>Director, Product Design at Rasa</strong> <span class="arrow">↗</span></a>
+        <span class="resume-org">Hamburg, Germany</span>
+      </div>
+    </li>
+    <li>
+      <span class="resume-date">2018 — 2021</span>
+      <div class="resume-entry">
+        <strong>Senior Product Designer at Rasa</strong>
+        <span class="resume-org">Hamburg, Germany</span>
+      </div>
+    </li>
+    <li>
+      <span class="resume-date">2015 — 2018</span>
+      <div class="resume-entry">
+        <strong>Product Designer</strong>
+        <span class="resume-org">Previous Role</span>
+      </div>
+    </li>
+    <li>
+      <span class="resume-date">2012 — 2015</span>
+      <div class="resume-entry">
+        <strong>UX Designer</strong>
+        <span class="resume-org">Previous Role</span>
+      </div>
+    </li>
+  </ul>
+</section>
+
+<section class="resume-section">
+  <div class="section-label">// side projects</div>
+  <ul class="resume-list">
+    <li>
+      <span class="resume-date">2020 — Now</span>
+      <div class="resume-entry">
+        <a href="https://www.lesoriginal.com"><strong>Les Original</strong> <span class="arrow">↗</span></a>
+        <span class="resume-org">Circular design, digital manufacturing, technical crafts</span>
+      </div>
+    </li>
+    <li>
+      <span class="resume-date">Ongoing</span>
+      <div class="resume-entry">
+        <strong>Open-source odds and ends</strong>
+        <span class="resume-org">Tools, templates, and experiments</span>
+      </div>
+    </li>
+  </ul>
+</section>
+
+<section class="resume-section">
+  <div class="section-label">// education</div>
+  <ul class="resume-list">
+    <li>
+      <span class="resume-date">2010 — 2012</span>
+      <div class="resume-entry">
+        <strong>Fellowship</strong>
+        <span class="resume-org">Canada</span>
+      </div>
+    </li>
+    <li>
+      <span class="resume-date">2006 — 2010</span>
+      <div class="resume-entry">
+        <strong>Design Degree</strong>
+        <span class="resume-org">University</span>
+      </div>
+    </li>
+  </ul>
+</section>
+
+<section class="resume-section">
+  <div class="section-label">// elsewhere</div>
+  <div class="things-list resume-links">
+    <div class="thing-item">
+      <a href="https://www.dribbble.com/marcs" class="thing-link">
+        <span>Dribbble</span>
+        <span class="thing-desc">marcs</span>
+        <span class="arrow">↗</span>
+      </a>
+    </div>
+    <div class="thing-item">
+      <a href="https://github.com/marcsist" class="thing-link">
+        <span>GitHub</span>
+        <span class="thing-desc">marcsist</span>
+        <span class="arrow">↗</span>
+      </a>
+    </div>
+    <div class="thing-item">
+      <a href="mailto:sup+marcsist@marcsist.com" class="thing-link">
+        <span>Email</span>
+        <span class="thing-desc">sup@marcsist.com</span>
+        <span class="arrow">→</span>
+      </a>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
This PR adds a dedicated resume page to the portfolio site with comprehensive styling and integrates it into the site navigation structure.

## Key Changes
- **New resume page** (`src/about/resume.md`): Created a full resume page with sections for experience, side projects, education, and external links (Dribbble, GitHub, email)
- **Resume layout template** (`src/includes/layouts/resume.njk`): Added a new layout template that extends the base layout with breadcrumb navigation
- **Resume styling** (`public/style.css`): Implemented comprehensive CSS for resume sections including:
  - Flexbox-based layout for resume entries with date/content alignment
  - Styled resume list items with proper spacing and typography
  - Muted color scheme for dates and organization names
  - Hover states for links with accent color transitions
  - Responsive design that stacks entries vertically on mobile (≤480px)
- **About section configuration** (`src/about/about.json`): Added layout configuration for the about section
- **Navigation link**: Updated about index page to include a link to the resume page

## Implementation Details
- Resume entries use a two-column flex layout with dates on the left (110px min-width) and content on the right
- External links include directional arrows that change color on hover
- Mobile responsive breakpoint adjusts flex direction to column and removes date min-width constraint
- Maintains consistent styling with existing site design using CSS variables for colors and spacing

https://claude.ai/code/session_01XUNCWGgt8T1ZJwhGnceAuU