### PR TITLE
Add sprite-lite THINGS item

### DIFF
--- a/src/things/sprite-lite.md
+++ b/src/things/sprite-lite.md
@@ -1,6 +1,6 @@
 ---
 title: sprite-lite
-description: A React library for animating agents that can think for themselves
+description: React library for animating agents that think for themselves
 link: https://github.com/marcsist/sprite-lite
 date: 2026-08-03
 category: software

--- a/src/things/sprite-lite.md
+++ b/src/things/sprite-lite.md
@@ -1,7 +1,7 @@
 ---
 title: sprite-lite
 description: React library for animating agents that think for themselves
-link: https://github.com/marcsist/sprite-lite
+link: https://marcsist.github.io/sprite-lite/
 date: 2026-08-03
 category: software
 tags: [things]

--- a/src/things/sprite-lite.md
+++ b/src/things/sprite-lite.md
@@ -1,0 +1,10 @@
+---
+title: sprite-lite
+description: A React library for animating agents that can think for themselves
+link: https://github.com/marcsist/sprite-lite
+date: 2026-08-03
+category: software
+tags: [things]
+layout: layouts/thing.njk
+chiptype: primary
+---


### PR DESCRIPTION
## Summary
- Adds a new THINGS entry for sprite-lite, a React library for animating self-directed agents, linking to https://github.com/marcsist/sprite-lite
- Dated today so it sorts to the top of the list, categorized as software (no template or config changes required)

## Test plan
- [ ] Run the Eleventy dev server and confirm the entry appears at the top of the THINGS page with a working link